### PR TITLE
Add CORS and token‑auth configuration

### DIFF
--- a/docs/auth_setup.md
+++ b/docs/auth_setup.md
@@ -1,0 +1,12 @@
+# Authentication & CORS Setup
+
+This repository now includes:
+
+1. **CORS configuration** – `corsheaders` is installed and `CORS_ALLOW_ALL_ORIGINS = True` in `farm_app/farm/farm/settings.py`.
+2. **Database host environment variable** – `DBHOST=db` is set in `docker-compose.yml` so Django can connect to the MySQL container both locally and in CI.
+3. **Token authentication** – DRF token auth is enabled via:
+   * `rest_framework.authtoken` added to `INSTALLED_APPS`
+   * `DEFAULT_AUTHENTICATION_CLASSES` includes `TokenAuthentication`
+   * `/api-token-auth/` endpoint exposed in `farm_app/farm/farm/urls.py`
+
+The front‑end (`react-frontend`) stores the token in `localStorage` after a successful login and attaches it to every request via an Axios interceptor.

--- a/farm_app/farm/farm/settings.py
+++ b/farm_app/farm/farm/settings.py
@@ -50,6 +50,8 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django_tables2',
     'rest_framework',
+    'rest_framework.authtoken',
+    'corsheaders',
 ]
 
 # ---------------------------------------------------------------------
@@ -62,6 +64,10 @@ REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     # A generous default; adjust as needed for production loads.
     "PAGE_SIZE": 500,
+    # Use token authentication by default for API endpoints.
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.TokenAuthentication",
+    ],
 }
 
 # ------------------------------------------------------------
@@ -87,6 +93,7 @@ MIGRATION_MODULES = {
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -133,10 +140,18 @@ DATABASES = {
         'NAME': DB,
         'USER': DBUSER,
         'PASSWORD': DBPW,
-        'HOST': os.getenv('DBHOST', 'localhost'),   # Or an IP Address that your DB is hosted on
+        # Default to Docker service name 'db' so Django can connect when running
+        # inside the container or during tests without requiring an env var.
+        'HOST': os.getenv('DBHOST', 'db'),   # Or an IP Address that your DB is hosted on
         'PORT': '3306',
     }
 }
+
+# ---------------------------------------------------------------------
+# CORS configuration – allow all origins for local development. In a real
+# deployment you would restrict this to your frontend domain.
+# ---------------------------------------------------------------------
+CORS_ALLOW_ALL_ORIGINS = True
 
 # Configure Django's test database to use a temporary MySQL schema. Django will
 # automatically prefix the name with ``test_`` when using MySQL, but we set it

--- a/farm_app/farm/farm/urls.py
+++ b/farm_app/farm/farm/urls.py
@@ -18,6 +18,8 @@ from django.urls import path, include
 
 # Import the Farm API view to expose it at the root level without the "farms/" prefix.
 from farms.views import FarmListCreateAPIView
+# Token authentication view provided by DRF
+from rest_framework.authtoken.views import obtain_auth_token
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -30,6 +32,8 @@ urlpatterns += [
     # Expose the Farm list/create view directly at ``/api/farms/`` for
     # external callers that do not need the ``farms/`` namespace.
     path('api/farms/', FarmListCreateAPIView.as_view(), name='api_farms_root'),
+    # Endpoint for obtaining a token (POST username/password)
+    path('api-token-auth/', obtain_auth_token, name='api_token_auth'),
 ]
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
Enable corsheaders, set DBHOST to Docker service name, add DRF token authentication.